### PR TITLE
Fix podspec to reflect actual version number

### DIFF
--- a/ColorPickerRow.podspec
+++ b/ColorPickerRow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ColorPickerRow'
-  s.version = '1.2.1'
+  s.version = '1.3.1'
   s.license = 'MIT'
   s.summary = 'A color picker row for use with the Eureka form library'
   s.homepage = 'https://github.com/EurekaCommunity/ColorPickerRow'
@@ -8,10 +8,11 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.ios.frameworks = 'UIKit', 'Foundation'
   s.source_files = 'ColorPicker/**/*.swift'
+  s.swift_version = '4.2'
   s.requires_arc = true
   s.author = "Mark Alldritt"
   s.dependencies = {
   	'Eureka' => '>= 3.0.0', 
-	'UIColor_Hex_Swift' => '>= 3.0.0'
+  	'UIColor_Hex_Swift' => '>= 3.0.0'
   }
 end


### PR DESCRIPTION
The 1.3.0 version does build against Swift 4.2 but when installed, it still reports 1.2.1 and builds against Swift 4. 

This branch addresses this problem.